### PR TITLE
Fix parsing of playlists with hidden videos

### DIFF
--- a/dist/sources/youtube.js
+++ b/dist/sources/youtube.js
@@ -30,7 +30,7 @@ async function getYoutubeAsSource(resource, isSearch) {
                     return { entries: [{ id: d.video_details.id, title: d.video_details.title, duration: Number(d.video_details.durationInSec || 0), uploader: d.video_details.channel?.name || "Unknown author" }] };
                 }
                 else {
-                    const d = await yt.playlist_info(resource);
+                    const d = await yt.playlist_info(resource, { incomplete: true });
                     if (!d)
                         throw new Error("NO_PLAYLIST");
                     await d.fetch();
@@ -61,7 +61,7 @@ async function getYoutubeAsSource(resource, isSearch) {
     if (url && url.searchParams.get("list") && url.searchParams.get("list").startsWith("FL_") || resource.startsWith("FL_"))
         throw new Error("Favorite list playlists cannot be fetched.");
     if (url && url.searchParams.has("list") || resource.startsWith("PL")) {
-        const pl = await yt.playlist_info(resource);
+        const pl = await yt.playlist_info(resource, { incomplete: true });
         if (!pl)
             throw new Error("NO_PLAYLIST");
         await pl.fetch();

--- a/src/sources/youtube.ts
+++ b/src/sources/youtube.ts
@@ -10,7 +10,7 @@ async function getYoutubeAsSource(resource: string, isSearch: boolean): Promise<
 					const d = await yt.video_basic_info(ID);
 					return { entries: [{ id: d.video_details.id as string, title: d.video_details.title as string, duration: Number(d.video_details.durationInSec as number || 0), uploader: d.video_details.channel?.name || "Unknown author" }] };
 				} else {
-					const d = await yt.playlist_info(resource);
+					const d = await yt.playlist_info(resource, { incomplete: true });
 					if (!d) throw new Error("NO_PLAYLIST");
 					await d.fetch();
 					const entries = [] as Array<import("play-dl/dist/YouTube/classes/Video").YouTubeVideo>;
@@ -38,7 +38,7 @@ async function getYoutubeAsSource(resource: string, isSearch: boolean): Promise<
 	if (url && url.searchParams.get("list") && url.searchParams.get("list")!.startsWith("FL_") || resource.startsWith("FL_")) throw new Error("Favorite list playlists cannot be fetched.");
 
 	if (url && url.searchParams.has("list") || resource.startsWith("PL")) {
-		const pl = await yt.playlist_info(resource);
+		const pl = await yt.playlist_info(resource, { incomplete: true });
 		if (!pl) throw new Error("NO_PLAYLIST");
 		await pl.fetch();
 		const entries = [] as Array<import("play-dl/dist/YouTube/classes/Video").YouTubeVideo>;


### PR DESCRIPTION
Allows YouTube playlists containing hidden videos, such as private or region locked videos, to be loaded.

From my testing:
Without this change playlists containing hidden videos will throw an error.
With this change playlists containing hidden videos will be loaded while ignoring any video that is hidden.

Relevant play-dl documentation:
https://play-dl.github.io/modules.html#playlist_info